### PR TITLE
update kxstudio-repos package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -215,8 +215,8 @@ runs:
       shell: bash
       run: |
         # custom repos
-        wget https://launchpad.net/~kxstudio-debian/+archive/kxstudio/+files/kxstudio-repos_11.1.0_all.deb
-        ${SUDO} dpkg -i kxstudio-repos_11.1.0_all.deb
+        wget https://launchpad.net/~kxstudio-debian/+archive/kxstudio/+files/kxstudio-repos_11.2.0_all.deb
+        ${SUDO} dpkg -i kxstudio-repos_11.2.0_all.deb
         ${SUDO} apt-get update -qq
         # build-deps
         ${SUDO} apt-get install -yqq libasound2-dev libdbus-1-dev libgl1-mesa-dev libglib2.0-dev liblo-dev libpulse-dev libx11-dev libxcursor-dev libxext-dev libxrandr-dev gperf


### PR DESCRIPTION
Hello,

I just got the action fail at "pluginval", it looks like the `kxstudio-repos` package was bumped from 11.1.0 to 11.2.0 at Launchpad.